### PR TITLE
Fixes #109 - ensure sl-form finds all nested controls

### DIFF
--- a/src/components/form/form.tsx
+++ b/src/components/form/form.tsx
@@ -184,6 +184,7 @@ export class Form {
     const tags = this.formControls.map(control => control.tag);
     return slot
       .assignedElements({ flatten: true })
+      .reduce((all, el) => all.concat(el, [...el.querySelectorAll('*')]), [])
       .filter(el => tags.includes(el.tagName.toLowerCase())) as HTMLElement[];
   }
 


### PR DESCRIPTION
Uses a deep `querySelectorAll` call to find all form controls inside `<sl-form>` slots.